### PR TITLE
Msteams notifs

### DIFF
--- a/examples/notified_task.py
+++ b/examples/notified_task.py
@@ -1,0 +1,35 @@
+"""
+Dont forget to configure luigi.cfg sections like this:
+
+[email]
+format=html
+method=msteams
+receiver=some@email
+sender=luigi-client-ra@host.com
+##  force_send=True
+
+[msteams]
+webhook_url_success=<someUrl>
+webhook_url_failure=<someUrl>
+
+"""
+import luigi
+from luigi.contrib.notifiers import NotifiedTaskMixin
+
+from dotenv import load_dotenv
+
+load_dotenv('local_testing.env', override=True)
+
+
+class TestNotifiedTask(luigi.Task, NotifiedTaskMixin):
+     """Example to send message after successful run of this Task.
+     """
+     teams_message_text = "My custom message"
+     teams_buttons = [("Button1", "https://gooogl.com"), ("Button1", "https://sharepoint.com")]
+
+     def run(self):
+          return 1
+
+if __name__ == "__main__":
+     t = TestNotifiedTask()
+     luigi.build([t], local_scheduler=True)

--- a/luigi/contrib/notifiers/__init__.py
+++ b/luigi/contrib/notifiers/__init__.py
@@ -1,0 +1,1 @@
+from luigi.contrib.notifiers.msteams import MsTeamsNotification, NotifiedTaskMixin

--- a/luigi/contrib/notifiers/msteams.py
+++ b/luigi/contrib/notifiers/msteams.py
@@ -43,7 +43,7 @@ class MsTeamsNotification:
         self.teams_msg.send()
 
 
-class NotifiedTask(luigi.Task):
+class NotifiedTaskMixin():
     # set optional text to show on task completion
     teams_message_text = None
     # button
@@ -69,7 +69,7 @@ class NotifiedTask(luigi.Task):
                     tm.add_button(button_tup[0], button_tup[1])
             tm.send()
 
-        super().__init__(*args, **kwargs)
+        #super().__init__(*args, **kwargs)
 
 
 if __name__ == "__main__":
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     load_dotenv('local_testing.env', override=True)
 
-    class TestNotifiedTask(NotifiedTask):
+    class TestNotifiedTask(luigi.Task, NotifiedTaskMixin):
         teams_message_text = "My custom message"
         teams_buttons = [("Button1", "https://gooogl.com"), ("Button1", "https://sharepoint.com")]
 

--- a/luigi/contrib/notifiers/msteams.py
+++ b/luigi/contrib/notifiers/msteams.py
@@ -69,23 +69,6 @@ class NotifiedTaskMixin():
                     tm.add_button(button_tup[0], button_tup[1])
             tm.send()
 
-        #super().__init__(*args, **kwargs)
-
-
-if __name__ == "__main__":
-    from dotenv import load_dotenv
-
-    load_dotenv('local_testing.env', override=True)
-
-    class TestNotifiedTask(luigi.Task, NotifiedTaskMixin):
-        teams_message_text = "My custom message"
-        teams_buttons = [("Button1", "https://gooogl.com"), ("Button1", "https://sharepoint.com")]
-
-        def run(self):
-            return 1
-
-    t = TestNotifiedTask()
-    luigi.build([t], local_scheduler=True)
 
 
 

--- a/luigi/contrib/notifiers/msteams.py
+++ b/luigi/contrib/notifiers/msteams.py
@@ -1,0 +1,91 @@
+import datetime
+import logging
+import luigi
+import re
+from luigi.notifications import msteams
+
+
+logger = logging.getLogger('luigi-interface')
+
+
+try:
+    import pymsteams
+except ImportError:
+    logger.warning("Loading `pymsteams` module without required package `pymsteams`. "
+                   "Will crash at runtime if MS Teams functionality is used.")
+
+
+class MsTeamsNotification:
+    def __init__(self, webhook_url: str, title: str, message: str, color: str = None):
+        self.webhook_url = webhook_url
+        self.title = title
+        self.message = message
+        self.teams_msg = pymsteams.connectorcard(self.webhook_url)
+        self.teams_msg.title(title)
+        self.teams_msg.text(message)
+        self.section = pymsteams.cardsection()
+        if color:
+            self.teams_msg.color(color)
+
+    def add_button(self, button_name, button_url):
+        """Add button to the message"""
+        if re.match("https?://", button_url):
+            self.teams_msg.addLinkButton(button_name, button_url)
+        else:
+            logger.warning("Button url must start with `https://`")
+
+    def add_section_keys(self, key, value):
+        self.section.addFact(factname=key, factvalue=value)
+
+    def send(self):
+        self.section.disableMarkdown()
+        self.teams_msg.addSection(self.section)
+        self.teams_msg.send()
+
+
+class NotifiedTask(luigi.Task):
+    # set optional text to show on task completion
+    teams_message_text = None
+    # button
+    teams_buttons: list[tuple[str, str]] = None
+
+    def __init__(self, *args, **kwargs):
+        event_handler = super().event_handler
+
+        @event_handler(luigi.Event.SUCCESS)
+        def celebrate_success(self):
+            """
+            Report success event by sending info into MS Teams Channel for successful report generation.
+            """
+            config = msteams()
+            message = self.teams_message_text or "Task finished with success :)"
+            tm = MsTeamsNotification(webhook_url=config.webhook_url_success,
+                                     title=self.get_task_family(),
+                                     message=message,
+                                     color="#4BB543")
+            tm.add_section_keys("Finished at:", datetime.datetime.now().strftime("%Y-%B-%d %H:%M:%S"))
+            if self.teams_buttons:
+                for button_tup in self.teams_buttons:
+                    tm.add_button(button_tup[0], button_tup[1])
+            tm.send()
+
+        super().__init__(*args, **kwargs)
+
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    load_dotenv('local_testing.env', override=True)
+
+    class TestNotifiedTask(NotifiedTask):
+        teams_message_text = "My custom message"
+        teams_buttons = [("Button1", "https://gooogl.com"), ("Button1", "https://sharepoint.com")]
+
+        def run(self):
+            return 1
+
+    t = TestNotifiedTask()
+    luigi.build([t], local_scheduler=True)
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ readme_note = """
 with open('README.rst') as fobj:
     long_description = "\n\n" + readme_note + "\n\n" + fobj.read()
 
-install_requires = ['python-dateutil>=2.7.5,<3', 'tenacity>=8,<9']
+install_requires = ['python-dateutil>=2.7.5,<3', 'tenacity>=8,<9', 'Pygments>=2.14.0']
 
 # Can't use python-daemon>=2.2.0 if on windows
 #     See https://pagure.io/python-daemon/issue/18


### PR DESCRIPTION
MS teams notification pack:
* usage except email on failed tasks, message goes directly to webhook channel
* use `luigi.Task` with `luigi.contrib.notifiers.NotifiedTaskMixin` which will after successful run send message to channel specified in config for success

```
[email]
format=html
method=msteams
receiver=some@email
sender=luigi-client-ra@host.com
##  force_send=True

[msteams]
webhook_url_success=<someUrl>
webhook_url_failure=<someUrl>

```